### PR TITLE
Bugfix: wxPython Black Box Glitch

### DIFF
--- a/deeplabcut/gui/welcome.py
+++ b/deeplabcut/gui/welcome.py
@@ -20,7 +20,6 @@ dlc = os.path.join(media_path,'dlc_1-01.png')
 class Welcome(wx.Panel):
 
     def __init__(self, parent,gui_size):
-        wx.Panel.__init__(self, parent)
         h=gui_size[0]
         w=gui_size[1]
         wx.Panel.__init__(self, parent, -1,style=wx.SUNKEN_BORDER,size=(h,w))


### PR DESCRIPTION
Welcome panel was initialized twice causing a black box to appear on the upper right corner of the main frame (Windows)